### PR TITLE
Add pre_analytics and post_analytics hooks

### DIFF
--- a/pythia/plugin.py
+++ b/pythia/plugin.py
@@ -18,10 +18,8 @@ class PluginHook(Enum):
     post_run_pixel_success = 650
     post_run_pixel_failed = 651
     post_run_all = 700
-    pre_analysis = 800
-    analyze_file = 900
-    analyze_pixel = 1000
-    post_analysis = 1100
+    pre_analytics = 800
+    post_analytics = 900
 
 
 def register_plugin_function(hook, fun, config, plugins):

--- a/pythia/tests/plugin_test.py
+++ b/pythia/tests/plugin_test.py
@@ -15,7 +15,7 @@ def test_register_with_invalid_hook():
 def test_register_with_invalid_fun():
     plugins = {}
     plugins1 = register_plugin_function(
-        PluginHook.analyze_file, "not a function", "", plugins
+        PluginHook.pre_analytics, "not a function", "", plugins
     )
     assert plugins1 == {}
 
@@ -23,7 +23,7 @@ def test_register_with_invalid_fun():
 def test_register_with_invalid_config():
     plugins = {}
     plugins1 = register_plugin_function(
-        PluginHook.post_analysis, sample_function, "", plugins
+        PluginHook.post_analytics, sample_function, "", plugins
     )
     assert plugins1 == {}
 
@@ -33,13 +33,13 @@ def test_register_twice():
     plugins1 = {}
     plugins2 = {}
     plugins1 = register_plugin_function(
-        PluginHook.analyze_file, sample_function, {}, plugins
+        PluginHook.pre_analytics, sample_function, {}, plugins
     )
     plugins2 = register_plugin_function(
-        PluginHook.analyze_file, sample_function, {"a": 1}, plugins1
+        PluginHook.pre_analytics, sample_function, {"a": 1}, plugins1
     )
     assert plugins1 == {
-        PluginHook.analyze_file: [{"fun": sample_function, "config": {}}]
+        PluginHook.pre_analytics: [{"fun": sample_function, "config": {}}]
     }
     assert plugins1 == plugins2
 


### PR DESCRIPTION
Analytics-related hooks were not working, so I removed them and added ``pre_analytics`` and ``post_analytics``, that are triggered either before Pythia starts calculating analytics on the output DSSAT data, or after it.

Suggested next version number: ``2.3.0``. Even though a breaking change was done and a major version *should* be incremented, this major breaking change affected only a feature that was not even implemented, only bare-bones of the interface existed. For this reason, I suggest treating this release as a "new feature" instead of "breaking change".

