### PR TITLE
Allow turning off initial conditions

### DIFF
--- a/pythia/functions.py
+++ b/pythia/functions.py
@@ -9,6 +9,8 @@ import pythia.soil_handler
 import pythia.template
 import pythia.util
 
+warning_ic_enabled_triggered = False
+
 
 def extract_raster(s):
     args = s.split("::")
@@ -94,6 +96,14 @@ def lookup_wth(k, run, context, _):
 
 
 def generate_ic_layers(k, run, context, _):
+    global warning_ic_enabled_triggered
+
+    if not context.get("ic_enabled", False):
+        if not warning_ic_enabled_triggered:
+            logging.warning("Initial Conditions are not enabled for this run, but a soil layer was requested.")
+            warning_ic_enabled_triggered = True
+        return None
+
     args = run[k].split("::")[1:]
     if args[0].startswith("$"):
         profile = args[0][1:]

--- a/pythia/template.py
+++ b/pythia/template.py
@@ -34,6 +34,7 @@ _t_formats = {
     "hdate": {"length": 5},
     "ppop": {"length": 5},
     "plrs": {"length": 3},
+    "ic_enabled": {"transform": int, "length": 2},
 }
 
 _t_date_fields = ["sdate", "fdate", "pfrst", "plast", "pdate", "hdate"]

--- a/pythia/template.py
+++ b/pythia/template.py
@@ -50,6 +50,8 @@ def init_engine(template_dir):
 def wrap_format(k, v):
     fmt = ""
     if k in _t_formats:
+        if "transform" in _t_formats[k]:
+            v = _t_formats[k]["transform"](v)
         if "raw" in _t_formats[k]:
             fmt = _t_formats[k]["raw"]
         elif "fmt" in _t_formats[k]:


### PR DESCRIPTION
Add support for turning off the soil initial conditions by omitting ``icsw%`` and ``icin`` in the run's config. Also added the generated variable ``ic_enabled`` to the template engine.

This allows to dynamically run simulations with or without initial conditions, by specifying or omitting the Available Water and Nitrogen levels.

An example of the usage of ``ic_enabled`` looks like:

```
*TREATMENTS                        -------------FACTOR LEVELS------------
@N R O C TNAME.................... CU FL SA IC MP MI MF MR MC MT ME MH SM
 1 1 1 0 Maize rainfed              1  1  0 {{ ic_enabled }}  1  0  1  1  0  0  1  0  1
 ```
 
 That way, ``IC`` will automatically toggle between `` 0`` and `` 1`` if ``icsw%`` and ``icin`` are present.
 
 Also, the calculation of soil layers are skipped in case ``icsw%`` and ``icin`` aren't present, but this doesn't seem to give any meaningful performance improvements in terms of CPU time and speed during the setup phase.