### PR TITLE
Add support for all of the IC variables in the template engine

### DIFF
--- a/docs/json.rst
+++ b/docs/json.rst
@@ -82,21 +82,23 @@ Supported DSSAT variables
 The following are the supported DSSAT variables. To add more variables, please extend ``template.py``.
 
 +-------+---------+-------+-------+
-| cname | icbl    | pdate | sno3  |
+| cname | nyers   | pdate | irrig |
 +-------+---------+-------+-------+
-| erain | icren   | pfrst | wsta  |
+| erain | flhst   | pfrst | wsta  |
 +-------+---------+-------+-------+
-| famn  | icres   | ph2ol | xcrd  |
+| famn  | fhdur   | ph2ol | xcrd  |
 +-------+---------+-------+-------+
-| fdap  | icrt    | plast | ycrd  |
+| fdap  | sdate   | plast | ycrd  |
 +-------+---------+-------+-------+
-| fdate | id_soil | ramt  |       |
+| fdate | id_soil | ramt  | ingeno|
 +-------+---------+-------+-------+
-| fdate | ingeno  | sdate |       |
+| fdate | icbl    | sh2o  | snh4  |
 +-------+---------+-------+-------+
-| fhdur | irrig   | sh2o  |       |
+| sno3  | icrt    | icnr  | icrn  |
 +-------+---------+-------+-------+
-| flhst | nyers   | snh4  |       |
+| icre  | icwd    | icres | icren |
++-------+---------+-------+-------+
+| icrep | icrip   | icrid |       |
 +-------+---------+-------+-------+
 
 **Note:** All dates are ISO formatted as ``YYYY-MM-DD``

--- a/pythia/template.py
+++ b/pythia/template.py
@@ -10,13 +10,6 @@ _t_formats = {
     "id_soil": {"align": ":<", "length": 10},
     "xcrd": {"fmt": ":>15.3f"},
     "ycrd": {"fmt": ":>15.3f"},
-    "icrt": {"length": 6},
-    "icres": {"length": 6},
-    "icren": {"length": 6},
-    "icbl": {"length": 6},
-    "sh2o": {"fmt": ":>6.3f"},
-    "snh4": {"fmt": ":>6.2f"},
-    "sno3": {"fmt": ":>6.2f"},
     "fdate": {"length": 5},
     "fdap": {"length": 5},
     "famn": {"length": 5},
@@ -34,6 +27,24 @@ _t_formats = {
     "hdate": {"length": 5},
     "ppop": {"length": 5},
     "plrs": {"length": 3},
+
+    # Initial Conditions (Soil Profiles)
+    "icbl": {"length": 6},
+    "sh2o": {"fmt": ":>6.3f"},
+    "snh4": {"fmt": ":>6.2f"},
+    "sno3": {"fmt": ":>6.2f"},
+
+    # Initial Conditions (Residue)
+    "icrt": {"length": 6},
+    "icnd": {"length": 6},
+    "icrn": {"length": 6},
+    "icre": {"length": 6},
+    "icwd": {"length": 6},
+    "icres": {"length": 6},
+    "icren": {"length": 6},
+    "icrep": {"length": 6},
+    "icrip": {"length": 6},
+    "icrid": {"length": 6},
 }
 
 _t_date_fields = ["sdate", "fdate", "pfrst", "plast", "pdate", "hdate"]


### PR DESCRIPTION
I added support for all DSSAT variables related to Initial Conditions. Some of them already existed, so I rearranged in the source code to keep it organized.

Variables: 

- ``icbl``
- ``sh2o``
- ``snh4``
- ``sno3``
- ``icrt``
- ``icnd``
- ``icrn``
- ``icre``
- ``icwd``
- ``icres``
- ``icren``
- ``icrep``
- ``icrip``
- ``icrid``