### PR TITLE
Added soil analysis variables

### DIFF
--- a/docs/json.rst
+++ b/docs/json.rst
@@ -98,6 +98,8 @@ The following are the supported DSSAT variables. To add more variables, please e
 +-------+---------+-------+-------+
 | flhst | nyers   | snh4  |       |
 +-------+---------+-------+-------+
+| sadat | smhb    | smpx  | smke  |
++-------+---------+-------+-------+
 
 **Note:** All dates are ISO formatted as ``YYYY-MM-DD``
 

--- a/pythia/template.py
+++ b/pythia/template.py
@@ -34,6 +34,12 @@ _t_formats = {
     "hdate": {"length": 5},
     "ppop": {"length": 5},
     "plrs": {"length": 3},
+
+    # Soil Analysis
+    "sadat": {"length": 5},
+    "smhb": {"length": 6},
+    "smpx": {"length": 6},
+    "smke": {"length": 6},
 }
 
 _t_date_fields = ["sdate", "fdate", "pfrst", "plast", "pdate", "hdate"]

--- a/pythia/template.py
+++ b/pythia/template.py
@@ -102,8 +102,8 @@ def auto_format_dict(d):
     for k in _t_envmod_fields:
         clean[k] = envmod_format("A0")
     for k, v in d.items():
-        if v == "-99" or v == -99:
-            clean[k] = wrap_format(k, v)
+        if v == "-99" or v == -99 or v is None:
+            clean[k] = wrap_format(k, -99)
         else:
             if k in _t_date_fields and "::" not in v:
                 clean[k] = pythia.util.to_julian_date(pythia.util.from_iso_date(v))


### PR DESCRIPTION
Make the template engine automatically convert ``None`` (passed with ``null`` in the JSON config) to ``-99``. Also added the following fields:

- ``sadat``
-  ``smhb``
- ``smpx``
- ``smke``