### PR TITLE
Error count bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 tags
 data/*
 pythia/__pycache__/*
+pythia/.idea/*
 .idea/*
 .vscode/*
 *.pyc

--- a/pythia/dssat.py
+++ b/pythia/dssat.py
@@ -24,7 +24,7 @@ def _run_dssat(details, config, plugins):
     out, err = dssat.communicate()
     # print("+", end="", flush=True)
 
-    error_count = len(out.decode().split("\n")) - 1
+    error_count = len(err.decode().split("\n")) - 1
     hook = pythia.plugin.PluginHook.post_run_pixel_success
     if error_count > 0:
         hook = pythia.plugin.PluginHook.post_run_pixel_failed


### PR DESCRIPTION
Previously, warnings and logging messages caused plugins to fail unecessarily. By changing the error_count stream from 'out' to 'err', this problem should be solved.